### PR TITLE
New option: using HPET instead of TSC for latency measurement

### DIFF
--- a/pspgen.c
+++ b/pspgen.c
@@ -847,7 +847,7 @@ skip_tx_packets:
                         uint64_t latency = timestamp - old_rdtsc;
                         */
                         struct timespec timestamp_old = *(struct timespec *)(buf + sizeof(struct timespec));
-                        uint64_t latency = (timestamp.tv_sec - timestamp_old.tv_sec) * 1e6 + (timestamp.tv_sec - timestamp_old.tv_nsec) / 1000;
+                        uint64_t latency = (timestamp.tv_sec - timestamp_old.tv_sec) * 1e6 + (timestamp.tv_nsec - timestamp_old.tv_nsec) / 1000;
                         ctx->cnt_latency ++;
                         ctx->accum_latency += latency;
                         /*


### PR DESCRIPTION
- Added:
  - Added an option(--use-hpet) using HPET(High Precision Event Timer) instead of TSC(Time Stamp Counter) for latency measurement.
  - Using HPET requires 3 prerequisites:
    - BIOS support (check if this command shows some entries: "grep hpet /proc/timer_list")
    - Kernel support (check if "CONFIG_HPET_MMAP" is enabled in your kernel option)
    - DPDK support (builded with "CONFIG_RTE_LIBEAL_USE_HPET" turned on)
